### PR TITLE
java2swift: add non-optional `as` function for superclassess to `JavaClassMacro`

### DIFF
--- a/Sources/JavaKitMacros/JavaClassMacro.swift
+++ b/Sources/JavaKitMacros/JavaClassMacro.swift
@@ -88,9 +88,9 @@ extension JavaClassMacro: MemberMacro {
       """
 
     let nonOptionalAs: DeclSyntax = """
-      /// It's not checking anything.
-      public func `as`<OtherClass: AnyJavaObject>(_: OtherClass.Type) -> OtherClass {
-          return OtherClass(javaHolder: javaHolder)
+      /// Casting to <\(raw: superclass)> will never be nil because <\(raw: className.split(separator: ".").last!)> extends it.
+      public func `as`(_: \(raw: superclass)) -> \(raw: superclass) {
+          return \(raw: superclass)(javaHolder: javaHolder)
       }
       """
 

--- a/Tests/JavaKitMacroTests/JavaClassMacroTests.swift
+++ b/Tests/JavaKitMacroTests/JavaClassMacroTests.swift
@@ -79,9 +79,9 @@ class JavaKitMacroTests: XCTestCase {
                 self.javaHolder = javaHolder
             }
 
-            /// It's not checking anything.
-            public func `as`<OtherClass: AnyJavaObject>(_: OtherClass.Type) -> OtherClass {
-                return OtherClass(javaHolder: javaHolder)
+            /// Casting to <JavaObject> will never be nil because <HelloWorld> extends it.
+            public func `as`(_: JavaObject) -> JavaObject {
+                return JavaObject(javaHolder: javaHolder)
             }
         }
       """,


### PR DESCRIPTION
- enhance the docs